### PR TITLE
Use stealth Puppeteer for scraping

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
-    "axios": "^1.6.0",
     "cheerio": "^1.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",

--- a/routes/scraper.routes.js
+++ b/routes/scraper.routes.js
@@ -9,21 +9,29 @@ const {
 // GET /api/scraper/all — scrape all sources without filters
 router.get('/all', async (req, res) => {
   try {
-    const results = await Promise.all([
+    const results = await Promise.allSettled([
       scrapeFacebookMarketplace(),
       scrapeOfferUp(),
       scrapeMercari()
     ]);
-    res.json({
-      listings: [
-        ...results[0].listings,
-        ...results[1].listings,
-        ...results[2].listings
-      ]
+
+    const listings = [];
+    results.forEach(r => {
+      if (r.status === 'fulfilled') {
+        listings.push(...r.value.listings);
+      } else {
+        console.error('❌ Scraper error:', r.reason);
+      }
     });
+
+    if (!listings.length) {
+      return res.status(500).json({ error: 'Scraping failed.' });
+    }
+
+    res.json({ listings });
   } catch (error) {
-    console.error("❌ Scraping error:", error);
-    res.status(500).json({ error: "Scraping failed." });
+    console.error('❌ Scraping error:', error);
+    res.status(500).json({ error: 'Scraping failed.' });
   }
 });
 
@@ -36,21 +44,29 @@ router.get('/prices', async (req, res) => {
   }
 
   try {
-    const results = await Promise.all([
-      scrapeFacebookMarketplace(),
-      scrapeOfferUp(),
-      scrapeMercari()
+    const results = await Promise.allSettled([
+      scrapeFacebookMarketplace(query),
+      scrapeOfferUp(query),
+      scrapeMercari(query)
     ]);
-    res.json({
-      listings: [
-        ...results[0].listings,
-        ...results[1].listings,
-        ...results[2].listings
-      ]
+
+    const listings = [];
+    results.forEach(r => {
+      if (r.status === 'fulfilled') {
+        listings.push(...r.value.listings);
+      } else {
+        console.error('❌ Scraper error:', r.reason);
+      }
     });
+
+    if (!listings.length) {
+      return res.status(500).json({ error: 'Scraping failed.' });
+    }
+
+    res.json({ listings });
   } catch (error) {
-    console.error("❌ Scraping error:", error);
-    res.status(500).json({ error: "Scraping failed." });
+    console.error('❌ Scraping error:', error);
+    res.status(500).json({ error: 'Scraping failed.' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add a helper to launch Puppeteer with the stealth plugin and custom user agent
- use this helper for Facebook, OfferUp and Mercari scrapers

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_684c014e0ab88325b8f665bdcff0f797